### PR TITLE
[packaging] Rename kernel-headers to linux-glibc-devel. JB#59595

### DIFF
--- a/linux-glibc-devel.changes
+++ b/linux-glibc-devel.changes
@@ -1,3 +1,6 @@
+* Mon Jan 22 2024 Matti Lehtimäki <matti.lehtimaki@jolla.com> - 3.18.136
+- Rename kernel-headers to linux-glibc-devel. JB#59595
+
 * Tue Feb 26 2019 Tomi Leppänen <tomi.leppanen@jolla.com> - 3.18.136
 - Backport patch for overlapping definitions. Contributes to JB#43919
 - Update to 3.18.136

--- a/linux-glibc-devel.spec
+++ b/linux-glibc-devel.spec
@@ -1,6 +1,5 @@
 Summary: Headers describing the kernel ABI
-Name: kernel-headers
-Group: System/Kernel
+Name: linux-glibc-devel
 License: GPLv2
 URL: http://www.kernel.org/
 
@@ -8,6 +7,7 @@ URL: http://www.kernel.org/
 Version: %{kversion}
 Release: 1
 Provides: kernel-headers = %{kversion}
+Obsoletes: kernel-headers <= %{kversion}
 
 #
 # A note about versions and patches.
@@ -32,7 +32,7 @@ Patch0: api-fix-compatibility-of-linux-in.h-with-netinet-in.patch
 BuildRequires:  findutils,  make >= 3.78, diffutils, gawk
 
 %description
-The kernel-headers package contains the header files that describe
+The linux-glibc-devel package contains the header files that describe
 the kernel ABI. This package is mostly used by the C library and some
 low level system software, and is only used indirectly by regular
 applications.


### PR DESCRIPTION
In build-compare there is a special case for handling packages named kernel-* which causes the build of this package to appear to change when it in reality does not. Rename package to match what OpenSUSE uses to fix the issue.